### PR TITLE
Fix BDD test setup to build binary automatically

### DIFF
--- a/test/bdd/main_test.go
+++ b/test/bdd/main_test.go
@@ -2,6 +2,8 @@ package bdd
 
 import (
 	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/DamianReeves/sync-tools/test/bdd/steps"
@@ -30,6 +32,11 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 }
 
 func TestMain(m *testing.M) {
+	// Build the sync-tools binary before running tests
+	if err := buildSyncToolsBinary(); err != nil {
+		os.Exit(1)
+	}
+
 	opts := godog.Options{
 		Format:        "pretty",
 		Paths:         []string{"../../features"},
@@ -47,4 +54,21 @@ func TestMain(m *testing.M) {
 	if suite.Run() != 0 {
 		os.Exit(1)
 	}
+}
+
+// buildSyncToolsBinary builds the sync-tools binary required for BDD tests
+func buildSyncToolsBinary() error {
+	// Get the project root directory (two levels up from test/bdd)
+	projectRoot, err := filepath.Abs("../..")
+	if err != nil {
+		return err
+	}
+
+	// Build the binary
+	cmd := exec.Command("go", "build", "-o", "sync-tools", "./cmd/sync-tools")
+	cmd.Dir = projectRoot
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
 }


### PR DESCRIPTION
## Summary
- Fix BDD test setup to build sync-tools binary automatically before running tests
- Remove dependency on pre-existing checked-in binary
- Ensure consistent test environment across CI/CD and local development

## Problem
All 57 BDD scenarios were failing with "fork/exec sync-tools: no such file or directory" because the tests expected a pre-built binary to exist. This prevented releases through the GitHub Actions workflow.

## Solution
- Added `buildSyncToolsBinary()` function to `TestMain` in `test/bdd/main_test.go`
- Binary is now built automatically using `go build -o sync-tools ./cmd/sync-tools`
- Tests build the binary on-demand as part of the test setup process
- Makefile already properly handled build dependencies for test targets

## Test plan
- [x] All 57/57 BDD scenarios now pass (verified with `make test-bdd`)
- [x] Binary builds correctly in project root directory
- [x] Test setup handles build errors gracefully
- [x] No checked-in binary dependency

## Verification
```bash
make test-bdd
# ✅ 57 scenarios, 57 passed, 0 skipped, 0 pending, 0 undefined, 0 failed
```

This fixes the failing tests that were preventing releases and ensures the release workflow can proceed successfully.

🤖 Generated with [Claude Code](https://claude.ai/code)